### PR TITLE
Bug fixed

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -97,7 +97,7 @@ class InCollegeConfig:
 
     def save_login(self, username: str) -> None:
         """Update current logged in user and write changes to json file."""
-        self.config['currentLogin'] = username
+        self.config['current_login'] = username
         with open(self.filename, 'w', encoding='utf-8') as f:
             json.dump(self.config, f, ensure_ascii=False, indent=2)
 


### PR DESCRIPTION
Fixed a bug that login status cannot be written in.

P.S. I thought I had fixed it in my last commit on Thursday. But I have no idea why it's still showing the wrong one in the current version. So I pushed this again.